### PR TITLE
Center button titles in the floating menu

### DIFF
--- a/src/app/shared/components/fab/fab-item/fab-item.component.html
+++ b/src/app/shared/components/fab/fab-item/fab-item.component.html
@@ -4,7 +4,7 @@
   (click)="emitClickEvent($event)"
 >
   <div class="content-wrapper" #contentref>
-    <div class="content" [style.display]="content ? 'block' : 'none'">
+    <div class="content" [style.display]="content ? 'flex' : 'none'">
       {{ content }}
     </div>
   </div>

--- a/src/app/shared/components/fab/fab-item/fab-item.component.scss
+++ b/src/app/shared/components/fab/fab-item/fab-item.component.scss
@@ -29,6 +29,7 @@
   padding: 2px 7px;
   border-radius: 3px;
   display: none;
+  align-items: center;
   font-size: 12px;
   height: 25px;
   margin-top: 4px;


### PR DESCRIPTION
Centraliza o título dos botões do menu flutuante ao alterar o display para flex e adicionar a regra de align-items como center