### PR TITLE
Allow editable net value input in invoice item

### DIFF
--- a/src/app/pages/invoices/invoice-item/invoice-item.component.html
+++ b/src/app/pages/invoices/invoice-item/invoice-item.component.html
@@ -382,7 +382,8 @@
               (focusout)="updateLastValues()"
               (ngModelChange)="
                 updateDependentValues(tempInvoice.products, 'product');
-                updateDependentValues(tempInvoice.stages, 'stage')
+                updateDependentValues(tempInvoice.stages, 'stage');
+                updateNetValue()
               "
             />
             <ng-container *ngIf="value.invalid && value.touched">
@@ -409,16 +410,33 @@
             </label>
             <input
               nbInput
-              [ngModel]="netValue"
+              [(ngModel)]="options.netValue"
+              #netValue="ngModel"
               id="input-net-value"
               name="netValue"
               placeholder="Valor liquido do contrato"
               fullWidth
               fieldSize="large"
+              [brmasker]="{
+                money: true,
+                thousand: '.',
+                decimalCaracter: ',',
+                decimal: 2
+              }"
+              [required]="validation.value.required"
+              [minlength]="validation.value.minLength"
+              [maxlength]="validation.value.maxLength"
               [status]="
-                value.dirty ? (value.invalid ? 'danger' : 'success') : 'basic'
+                netValue.dirty
+                  ? netValue.invalid
+                    ? 'danger'
+                    : 'success'
+                  : 'basic'
               "
-              [readonly]="true"
+              [attr.aria-invalid]="
+                netValue.invalid && netValue.touched ? true : null
+              "
+              (ngModelChange)="updateGrossValue()"
             />
           </div>
         </div>

--- a/src/app/pages/invoices/invoice-item/invoice-item.component.html
+++ b/src/app/pages/invoices/invoice-item/invoice-item.component.html
@@ -436,7 +436,11 @@
               [attr.aria-invalid]="
                 netValue.invalid && netValue.touched ? true : null
               "
-              (ngModelChange)="updateGrossValue()"
+              (ngModelChange)="
+                updateGrossValue();
+                updateDependentValues(tempInvoice.products, 'product');
+                updateDependentValues(tempInvoice.stages, 'stage')
+              "
             />
           </div>
         </div>

--- a/src/app/pages/invoices/invoice-item/invoice-item.component.ts
+++ b/src/app/pages/invoices/invoice-item/invoice-item.component.ts
@@ -88,6 +88,7 @@ export class InvoiceItemComponent implements OnInit, OnDestroy {
     lastValue: '',
     lastProducts: [] as InvoiceProduct[],
     lastStages: [] as InvoiceStage[],
+    netValue: '0,00',
   };
   destroy$ = new Subject<void>();
   editing = false;
@@ -110,16 +111,6 @@ export class InvoiceItemComponent implements OnInit, OnDestroy {
   USER_COORDINATIONS: string[] = [];
   tStatus = INVOICE_STATOOS;
   STATOOS = Object.values(INVOICE_STATOOS);
-
-  get netValue(): string {
-    if (!this.tempInvoice.value && !this.tempInvoice.administration)
-      return '0,00';
-    return this.contractService.toNetValue(
-      this.tempInvoice.value,
-      this.utils.nfPercentage(this.tempInvoice),
-      this.utils.nortanPercentage(this.tempInvoice)
-    );
-  }
 
   constructor(
     private dialogService: NbDialogService,
@@ -171,6 +162,7 @@ export class InvoiceItemComponent implements OnInit, OnDestroy {
       this.updateDependentValues(this.tempInvoice.products, 'product');
       this.updateDependentValues(this.tempInvoice.stages, 'stage');
       this.updateTotal('material');
+      this.updateNetValue();
     } else {
       this.tempInvoice = new Invoice();
       this.userService.currentUser$.pipe(take(1)).subscribe((user) => {
@@ -686,6 +678,28 @@ export class InvoiceItemComponent implements OnInit, OnDestroy {
         this.stringUtil.moneyToNumber(array[idx].value) *
           this.stringUtil.moneyToNumber(array[idx].amount)
       );
+  }
+
+  updateNetValue(): void {
+    if (!this.tempInvoice.value && !this.tempInvoice.administration) {
+      this.options.netValue = '0,00';
+    } else {
+      this.options.netValue = this.contractService.toNetValue(
+        this.tempInvoice.value,
+        this.utils.nfPercentage(this.tempInvoice),
+        this.utils.nortanPercentage(this.tempInvoice)
+      );
+    }
+  }
+
+  updateGrossValue(): void {
+    const newInvoiceValue = this.contractService.toGrossValue(
+      this.options.netValue,
+      this.utils.nfPercentage(this.tempInvoice),
+      this.utils.nortanPercentage(this.tempInvoice)
+    );
+
+    this.tempInvoice.value = newInvoiceValue;
   }
 }
 


### PR DESCRIPTION
- Permite que o input de valor líquido do orçamento seja editado pelo usuário. Ao editar o input, o valor bruto correspondente é atualizado