### PR TITLE
Fix non-unique expense code in add and clean

### DIFF
--- a/src/app/pages/contracts/contract-item/expense-item/expense-item.component.ts
+++ b/src/app/pages/contracts/contract-item/expense-item/expense-item.component.ts
@@ -344,6 +344,8 @@ export class ExpenseItemComponent
   }
 
   addAndClean(): void {
+    this.contract.createdExpenses += 1;
+    this.expense.code = '#' + this.contract.createdExpenses.toString();
     this.newExpense$.next();
     this.expense.uploadedFiles = cloneDeep(this.uploadedFiles);
     this.contract.expenses.push(cloneDeep(this.expense));


### PR DESCRIPTION
Ao adicionar uma despesa clicando em "Adicionar outro", as despesas eram adicionadas com o mesmo código. Isso ocorria porque o contador de despesas do contrato não era incrementado e o código da despesa não era atualizado a cada nova despesa adicionada pela função chamada ao clicar no botão "Adicionar outro".

Foi adicionado o incremento do contador e a atualização do código na respectiva função.