### PR TITLE
Fix faulty colors in colaborator gross value

### DIFF
--- a/src/app/pages/contracts/contract-item/contract-item.component.html
+++ b/src/app/pages/contracts/contract-item/contract-item.component.html
@@ -648,12 +648,8 @@
               <div
                 class="col-2"
                 [ngClass]="{
-                  danger:
-                    teamTotal.grossValue !== contract.value &&
-                    teamTotal.grossValue !== '0,00',
-                  success:
-                    teamTotal.grossValue === contract.value &&
-                    teamTotal.grossValue !== '0,00'
+                  danger: !isGrossValueOK(),
+                  success: isGrossValueOK()
                 }"
               >
                 R$ {{ teamTotal.grossValue }}
@@ -661,12 +657,8 @@
               <div
                 class="col-2"
                 [ngClass]="{
-                  danger:
-                    teamTotal.netValue !== contract.liquid &&
-                    teamTotal.netValue !== '0,00',
-                  success:
-                    teamTotal.netValue === contract.liquid &&
-                    teamTotal.netValue !== '0,00'
+                  danger: !isNetValueOK(),
+                  success: isNetValueOK()
                 }"
               >
                 R$ {{ teamTotal.netValue }}

--- a/src/app/pages/contracts/contract-item/contract-item.component.ts
+++ b/src/app/pages/contracts/contract-item/contract-item.component.ts
@@ -654,4 +654,20 @@ export class ContractItemComponent implements OnInit {
   expenseIndex(code: 'string'): number {
     return this.contract.expenses.findIndex((expense) => expense.code == code);
   }
+
+  isGrossValueOK(): boolean {
+    return (
+      this.stringUtil.numberToMoney(
+        this.stringUtil.moneyToNumber(this.teamTotal.grossValue) +
+          this.contractService.getComissionsSum(this.contract)
+      ) === this.contract.value && this.teamTotal.grossValue !== '0,00'
+    );
+  }
+
+  isNetValueOK(): boolean {
+    return (
+      this.teamTotal.netValue === this.contract.liquid &&
+      this.teamTotal.netValue !== '0,00'
+    );
+  }
 }

--- a/src/app/shared/services/contract.service.ts
+++ b/src/app/shared/services/contract.service.ts
@@ -317,14 +317,19 @@ export class ContractService implements OnDestroy {
   }
 
   subtractComissions(contractValue: string, contract: Contract): string {
-    const comissions = contract['expenses'].reduce((sum, expense) => {
-      if (expense.type == EXPENSE_TYPES.COMISSAO)
-        sum += this.stringUtil.moneyToNumber(expense.value);
-      return sum;
-    }, 0);
+    const comissionsSum = this.getComissionsSum(contract);
 
     return this.stringUtil.numberToMoney(
-      this.stringUtil.moneyToNumber(contractValue) - comissions
+      this.stringUtil.moneyToNumber(contractValue) - comissionsSum
     );
+  }
+
+  getComissionsSum(contract: Contract): number {
+    return contract.expenses.reduce((sum, expense) => {
+      if (expense.type == EXPENSE_TYPES.COMISSAO) {
+        sum += this.stringUtil.moneyToNumber(expense.value);
+      }
+      return sum;
+    }, 0);
   }
 }


### PR DESCRIPTION
O valor bruto somado na seção de colaborador de um contrato poderia receber a cor vermelha em sua fonte caso o valor bruto somado do time fosse diferente do valor bruto do contrato.

Isso ocorria porque o valor das comissões não era adicionado ao valor bruto somado do time. Ao adicionar o valor, a cor é corrigida.

Havia a possibilidade de adicionar o valor das comissões direto na variável que armazenava o valor bruto somado do time, mas optei por adicionar o valor somente na verificação do ngClass.