### PR TITLE
Add default distribution in contracts

### DIFF
--- a/src/app/pages/contracts/contract-item/contract-item.component.ts
+++ b/src/app/pages/contracts/contract-item/contract-item.component.ts
@@ -250,41 +250,7 @@ export class ContractItemComponent implements OnInit {
     this.updateLiquid();
     this.calculatePaidValue();
     this.calculateBalance();
-    if (
-      this.contract.invoice &&
-      (!this.contract.team || this.contract.team?.length == 0)
-    ) {
-      const invoice = this.invoiceService.idToInvoice(this.contract.invoice);
-      if (invoice.team) {
-        this.contract.team = cloneDeep(invoice.team).map((member) => ({
-          user: member.user,
-          coordination: member.coordination,
-          distribution: '',
-          netValue: '0,00',
-          grossValue: '0,00',
-        }));
-        this.contract.team.unshift({
-          user: invoice.author,
-          coordination: invoice.coordination,
-          distribution: '',
-          netValue: '0,00',
-          grossValue: '0,00',
-        });
-      }
-    } else {
-      this.contract.team = this.contract.team.map((member, idx) => {
-        member.netValue = this.stringUtil.applyPercentage(
-          this.contract.liquid,
-          member.distribution
-        );
-        member.grossValue = this.contractService.toGrossValue(
-          member.netValue,
-          this.options.notaFiscal,
-          this.options.nortanPercentage
-        );
-        return member;
-      });
-    }
+    this.applyDistribution();
     this.updateTeamTotal();
     this.userData = this.completerService
       .local(this.userService.getUsersList(), 'fullName', 'fullName')
@@ -669,5 +635,20 @@ export class ContractItemComponent implements OnInit {
       this.teamTotal.netValue === this.contract.liquid &&
       this.teamTotal.netValue !== '0,00'
     );
+  }
+
+  applyDistribution(): void {
+    this.contract.team = this.contract.team.map((member) => {
+      member.netValue = this.stringUtil.applyPercentage(
+        this.contract.liquid,
+        member.distribution
+      );
+      member.grossValue = this.contractService.toGrossValue(
+        member.netValue,
+        this.options.notaFiscal,
+        this.options.nortanPercentage
+      );
+      return member;
+    });
   }
 }

--- a/src/app/shared/services/contract.service.ts
+++ b/src/app/shared/services/contract.service.ts
@@ -336,6 +336,7 @@ export class ContractService implements OnDestroy {
   }
 
   setDefaultDistribution(contract: Contract, invoice: Invoice): Contract {
+    const tmpContract = cloneDeep(contract);
     // +1 because the current user isn't in the invoice team
     const teamSize = invoice.team.length + 1;
     const defaultDistribution = this.stringUtil.numberToString(
@@ -343,16 +344,16 @@ export class ContractService implements OnDestroy {
       20
     );
     const defaultNetValue = this.stringUtil.applyPercentage(
-      contract.liquid,
+      tmpContract.liquid,
       defaultDistribution
     );
     const defaultGrossValue = this.toGrossValue(
       defaultNetValue,
-      this.utils.nfPercentage(contract),
-      this.utils.nortanPercentage(contract)
+      this.utils.nfPercentage(tmpContract),
+      this.utils.nortanPercentage(tmpContract)
     );
 
-    contract.team = cloneDeep(invoice.team).map((member) => ({
+    tmpContract.team = cloneDeep(invoice.team).map((member) => ({
       user: member.user,
       coordination: member.coordination,
       distribution: defaultDistribution,
@@ -360,7 +361,7 @@ export class ContractService implements OnDestroy {
       grossValue: defaultGrossValue,
     }));
 
-    contract.team.unshift({
+    tmpContract.team.unshift({
       user: invoice.author,
       coordination: invoice.coordination,
       distribution: defaultDistribution,
@@ -368,6 +369,6 @@ export class ContractService implements OnDestroy {
       grossValue: defaultGrossValue,
     });
 
-    return contract;
+    return tmpContract;
   }
 }


### PR DESCRIPTION
A distribuição dos contratos ocorre quando o mesmo é exibido. Se o contrato já possuir um time, a distribuição é feita levando em consideração esse time.

Mas, caso não tenha, a distruibição padrão será calculada de acordo com a quantidade de pessoas no time do orçamento. Anteriormente, a distribuição recebia "placeholders". 

Fiquei em dúvida se eu deveria ter incluído as funções de distribuição no service dos contratos ou deixar elas no contract-item mesmo.