### PR TITLE
Add custom directive to select all text when clicking in inputs with brMask

### DIFF
--- a/src/app/auth/register/register.component.html
+++ b/src/app/auth/register/register.component.html
@@ -129,6 +129,7 @@
       fullWidth
       fieldSize="large"
       [brmasker]="{ phone: true }"
+      ngxSelectAllText
       [required]="validation.phone.required"
       [minlength]="validation.phone.minLength"
       [maxlength]="validation.phone.maxLength"

--- a/src/app/pages/contractors/contractor-item/contractor-item.component.html
+++ b/src/app/pages/contractors/contractor-item/contractor-item.component.html
@@ -72,6 +72,7 @@
       fullWidth
       fieldSize="large"
       [brmasker]="{ person: true }"
+      ngxSelectAllText
       [required]="validation.document.required"
       [minlength]="validation.document.minLength"
       [maxlength]="validation.document.maxLength"

--- a/src/app/pages/contracts/contract-item/contract-item.component.html
+++ b/src/app/pages/contracts/contract-item/contract-item.component.html
@@ -486,31 +486,32 @@
               />
             </div>
           </div>
-          <div class="col-6 col-md-2">
-            <div class="form-control-group">
-              <label class="label" for="input-net-value">R$ Líquido:</label>
-              <input
-                nbInput
-                [(ngModel)]="teamMember.netValue"
-                (ngModelChange)="updatePercentage()"
-                #netValue="ngModel"
-                id="input-netValue"
-                name="netValue"
-                placeholder="Valor líquido"
-                fullWidth
-                fieldSize="large"
-                [brmasker]="{
-                  money: true,
-                  thousand: '.',
-                  decimalCaracter: ',',
-                  decimal: 2
-                }"
-                [status]="netValue.value ? 'success' : 'basic'"
-                [attr.aria-invalid]="
-                  netValue.invalid && netValue.touched ? true : null
-                "
-              />
-            </div>
+        </div>
+        <div class="col-6 col-md-2">
+          <div class="form-control-group">
+            <label class="label" for="input-net-value">R$ Líquido:</label>
+            <input
+              nbInput
+              [(ngModel)]="teamMember.netValue"
+              (ngModelChange)="updatePercentage()"
+              #netValue="ngModel"
+              id="input-netValue"
+              name="netValue"
+              placeholder="Valor líquido"
+              fullWidth
+              fieldSize="large"
+              [brmasker]="{
+                money: true,
+                thousand: '.',
+                decimalCaracter: ',',
+                decimal: 2
+              }"
+              ngxSelectAllText
+              [status]="netValue.value ? 'success' : 'basic'"
+              [attr.aria-invalid]="
+                netValue.invalid && netValue.touched ? true : null
+              "
+            />
           </div>
           <div class="col-6 col-md-2">
             <div class="form-control-group">
@@ -531,6 +532,7 @@
                   decimalCaracter: ',',
                   decimal: 2
                 }"
+                ngxSelectAllText
                 [status]="distribution.value ? 'success' : 'basic'"
                 [attr.aria-invalid]="
                   distribution.invalid && distribution.touched ? true : null
@@ -616,93 +618,79 @@
                       decimalCaracter: ',',
                       decimal: 2
                     }"
-                    [status]="invoice.team[i].netValue ? 'basic' : 'danger'"
-                  />
-                </div>
-                <div
-                  class="col-6 col-md-2"
-                  style="display: flex; align-items: center"
-                >
-                  <input
-                    nbInput
-                    [(ngModel)]="invoice.team[i].distribution"
-                    (ngModelChange)="updateValue(i)"
-                    id="input-distribution-{{ i }}"
-                    name="distribution-{{ i }}"
-                    placeholder="Porcentagem distribuida"
-                    fullWidth
-                    [brmasker]="{
-                      money: true,
-                      thousand: '.',
-                      decimalCaracter: ',',
-                      decimal: 2
-                    }"
-                    [status]="invoice.team[i].distribution ? 'basic' : 'danger'"
-                  />
-                  %
-                </div>
-                <div
-                  class="col-12 col-md-1 list-erase"
-                  *ngIf="i != 0 && isEditionGranted"
-                >
-                  <nb-icon
-                    class="xIcon"
-                    status="basic"
-                    icon="trash-2-outline"
-                    pack="eva"
-                    (click)="
-                      invoice.team.splice(i, 1);
-                      updateTeamTotal();
-                      memberChanged$.next(true)
-                    "
-                    [options]="{ animation: { type: 'shake' } }"
-                  ></nb-icon>
-                </div>
+                  ngxSelectAllText
+                  [status]="contract.team[i].netValue ? 'basic' : 'danger'"
+                />
               </div>
-            </nb-list-item>
-            <nb-list-item *ngIf="!utils.isPhone()">
-              <div class="row irow totalRow">
-                <div class="col-2">
-                  Restante:
-                  {{
-                    stringUtil.subtractMoney(
-                      contract.liquid,
-                      teamTotal.netValue
-                    )
-                  }}
-                </div>
-                <div class="col-3" style="text-align: right">Total:</div>
-                <div
-                  class="col-2"
-                  [ngClass]="{
-                    danger: !isGrossValueOK(),
-                    success: isGrossValueOK()
+              <div
+                class="col-6 col-md-2"
+                style="display: flex; align-items: center"
+              >
+                <input
+                  nbInput
+                  [(ngModel)]="contract.team[i].distribution"
+                  (ngModelChange)="updateValue(i)"
+                  id="input-distribution-{{ i }}"
+                  name="distribution-{{ i }}"
+                  placeholder="Porcentagem distribuida"
+                  fullWidth
+                  [brmasker]="{
+                    money: true,
+                    thousand: '.',
+                    decimalCaracter: ',',
+                    decimal: 2
                   }"
-                >
-                  R$ {{ teamTotal.grossValue }}
-                </div>
-                <div
-                  class="col-2"
-                  [ngClass]="{
-                    danger: !isNetValueOK(),
-                    success: isNetValueOK()
-                  }"
-                >
-                  R$ {{ teamTotal.netValue }}
-                </div>
-                <div
-                  class="col-2"
-                  [ngClass]="{
-                    danger: teamTotal.distribution != '0,00',
-                    success: teamTotal.distribution == '100,00'
-                  }"
-                >
-                  {{ teamTotal.distribution }}%
-                </div>
-                <div class="col-1"></div>
+                  ngxSelectAllText
+                  [status]="contract.team[i].distribution ? 'basic' : 'danger'"
+                />
+                %
               </div>
-            </nb-list-item>
-          </nb-list>
+              <div class="col-12 col-md-1 list-erase">
+                <nb-icon
+                  class="xIcon"
+                  status="basic"
+                  icon="trash-2-outline"
+                  pack="eva"
+                  (click)="
+                    contract.team.splice(i, 1);
+                    updateTeamTotal();
+                    memberChanged$.next(true)
+                  "
+                  [options]="{ animation: { type: 'shake' } }"
+                ></nb-icon>
+              </div>
+            </div>
+          </nb-list-item>
+          <nb-list-item *ngIf="!utils.isPhone()">
+            <div class="row irow totalRow">
+              <div class="col-2">
+                Restante:
+                {{
+                  stringUtil.subtractMoney(contract.liquid, teamTotal.netValue)
+                }}
+              </div>
+              <div class="col-3" style="text-align: right">Total:</div>
+              <div
+                class="col-2"
+                [ngClass]="{
+                  danger: !isGrossValueOK(),
+                  success: isGrossValueOK()
+                }"
+              >
+                R$ {{ teamTotal.grossValue }}
+              </div>
+              <div
+                class="col-2"
+                [ngClass]="{
+                  danger: !isNetValueOK(),
+                  success: isNetValueOK()
+                }"
+              >
+                R$ {{ teamTotal.netValue }}
+              </div>
+            </div>
+          </nb-list-item>
+        </nb-list>
           <div class="col-6">
             <div class="form-control-group">
               <label class="label" for="input-hasISS">
@@ -737,92 +725,94 @@
                 <nb-option [value]="false">Não</nb-option>
               </nb-select>
             </div>
+        </div>
+        <div class="col-6">
+          <div class="form-control-group">
+            <label class="label" for="input-iss">Alíquota do ISS:</label>
+            <input
+              nbInput
+              [(ngModel)]="contract.ISS"
+              #iss="ngModel"
+              id="input-iss"
+              name="iss"
+              placeholder="Alíquota"
+              fullWidth
+              fieldSize="large"
+              [brmasker]="{
+                money: true,
+                thousand: '.',
+                decimalCaracter: ',',
+                decimal: 2
+              }"
+              ngxSelectAllText
+              [disabled]="!hasISS.value"
+              [required]="validation.ISS?.required"
+              [status]="
+                iss.dirty ? (iss.invalid ? 'danger' : 'success') : 'basic'
+              "
+              [attr.aria-invalid]="iss.invalid && iss.touched ? true : null"
+              (ngModelChange)="updateLiquid()"
+            />
           </div>
-          <div class="col-6">
-            <div class="form-control-group">
-              <label class="label" for="input-iss">Alíquota do ISS:</label>
-              <input
-                nbInput
-                [(ngModel)]="contract.ISS"
-                #iss="ngModel"
-                id="input-iss"
-                name="iss"
-                placeholder="Alíquota"
-                fullWidth
-                fieldSize="large"
-                [brmasker]="{
-                  money: true,
-                  thousand: '.',
-                  decimalCaracter: ',',
-                  decimal: 2
-                }"
-                [disabled]="!hasISS.value"
-                [required]="validation.ISS?.required"
-                [status]="
-                  iss.dirty ? (iss.invalid ? 'danger' : 'success') : 'basic'
-                "
-                [attr.aria-invalid]="iss.invalid && iss.touched ? true : null"
-                (ngModelChange)="updateLiquid()"
-              />
-            </div>
+        </div>
+        <div class="col-6 col-md-4">
+          <div class="form-control-group">
+            <label class="label" for="input-balance">Caixa:</label>
+            <input
+              nbInput
+              [(ngModel)]="contract.balance"
+              #balance="ngModel"
+              id="input-balance"
+              name="balance"
+              placeholder="Balanço do contrato"
+              fullWidth
+              fieldSize="large"
+              [brmasker]="{
+                money: true,
+                thousand: '.',
+                decimalCaracter: ',',
+                decimal: 2
+              }"
+              ngxSelectAllText
+              [required]="validation.balance?.required"
+              [status]="
+                balance.invalid || contract.balance[0] == '-'
+                  ? 'danger'
+                  : 'basic'
+              "
+              [attr.aria-invalid]="
+                balance.invalid && balance.touched ? true : null
+              "
+              [readonly]="true"
+            />
           </div>
-          <div class="col-6 col-md-4">
-            <div class="form-control-group">
-              <label class="label" for="input-balance">Caixa:</label>
-              <input
-                nbInput
-                [(ngModel)]="contract.balance"
-                #balance="ngModel"
-                id="input-balance"
-                name="balance"
-                placeholder="Balanço do contrato"
-                fullWidth
-                fieldSize="large"
-                [brmasker]="{
-                  money: true,
-                  thousand: '.',
-                  decimalCaracter: ',',
-                  decimal: 2
-                }"
-                [required]="validation.balance?.required"
-                [status]="
-                  balance.invalid || contract.balance[0] == '-'
-                    ? 'danger'
-                    : 'basic'
-                "
-                [attr.aria-invalid]="
-                  balance.invalid && balance.touched ? true : null
-                "
-                [readonly]="true"
-              />
-            </div>
-          </div>
-          <div class="col-6 col-md-4">
-            <div class="form-control-group">
-              <label class="label" for="input-paid">Valor pago:</label>
-              <input
-                nbInput
-                [(ngModel)]="options.paid"
-                #paid="ngModel"
-                id="input-paid"
-                name="paid"
-                placeholder="Valor pago"
-                fullWidth
-                fieldSize="large"
-                [brmasker]="{
-                  money: true,
-                  thousand: '.',
-                  decimalCaracter: ',',
-                  decimal: 2
-                }"
-                [required]="validation.paid?.required"
-                [status]="
-                  paid.dirty ? (paid.invalid ? 'danger' : 'success') : 'basic'
-                "
-                [attr.aria-invalid]="paid.invalid && paid.touched ? true : null"
-                [readonly]="true"
-              />
-            </div>
+        </div>
+        <div class="col-6 col-md-4">
+          <div class="form-control-group">
+            <label class="label" for="input-paid">Valor pago:</label>
+            <input
+              nbInput
+              [(ngModel)]="options.paid"
+              #paid="ngModel"
+              id="input-paid"
+              name="paid"
+              placeholder="Valor pago"
+              fullWidth
+              fieldSize="large"
+              [brmasker]="{
+                money: true,
+                thousand: '.',
+                decimalCaracter: ',',
+                decimal: 2
+              }"
+              ngxSelectAllText
+              [required]="validation.paid?.required"
+              [status]="
+                paid.dirty ? (paid.invalid ? 'danger' : 'success') : 'basic'
+              "
+              [attr.aria-invalid]="paid.invalid && paid.touched ? true : null"
+              [readonly]="true"
+            />
           </div>
           <div class="col-6 col-md-2">
             <div class="form-control-group">

--- a/src/app/pages/contracts/contract-item/contract-item.component.html
+++ b/src/app/pages/contracts/contract-item/contract-item.component.html
@@ -525,17 +525,17 @@
                 name="distribution"
                 placeholder="Porcentagem distribuida"
                 fullWidth
-                fieldSize="large"
-                [brmasker]="{
-                  money: true,
-                  thousand: '.',
-                  decimalCaracter: ',',
-                  decimal: 2
-                }"
-                ngxSelectAllText
-                [status]="distribution.value ? 'success' : 'basic'"
-                [attr.aria-invalid]="
-                  distribution.invalid && distribution.touched ? true : null
+              fieldSize="large"
+              [brmasker]="{
+                money: true,
+                thousand: '.',
+                decimalCaracter: ',',
+                decimal: 20
+              }"
+              ngxSelectAllText
+              [status]="distribution.value ? 'success' : 'basic'"
+              [attr.aria-invalid]="
+                distribution.invalid && distribution.touched ? true : null
                 "
               />
             </div>
@@ -545,6 +545,7 @@
               nbButton
               type="button"
               fullWidth
+
               status="primary"
               size="large"
               style="margin-top: 28px"
@@ -638,7 +639,7 @@
                     money: true,
                     thousand: '.',
                     decimalCaracter: ',',
-                    decimal: 2
+                    decimal: 20
                   }"
                   ngxSelectAllText
                   [status]="contract.team[i].distribution ? 'basic' : 'danger'"

--- a/src/app/pages/contracts/contract-item/contract-item.component.html
+++ b/src/app/pages/contracts/contract-item/contract-item.component.html
@@ -486,32 +486,32 @@
               />
             </div>
           </div>
-        </div>
-        <div class="col-6 col-md-2">
-          <div class="form-control-group">
-            <label class="label" for="input-net-value">R$ Líquido:</label>
-            <input
-              nbInput
-              [(ngModel)]="teamMember.netValue"
-              (ngModelChange)="updatePercentage()"
-              #netValue="ngModel"
-              id="input-netValue"
-              name="netValue"
-              placeholder="Valor líquido"
-              fullWidth
-              fieldSize="large"
-              [brmasker]="{
-                money: true,
-                thousand: '.',
-                decimalCaracter: ',',
-                decimal: 2
-              }"
-              ngxSelectAllText
-              [status]="netValue.value ? 'success' : 'basic'"
-              [attr.aria-invalid]="
-                netValue.invalid && netValue.touched ? true : null
-              "
-            />
+          <div class="col-6 col-md-2">
+            <div class="form-control-group">
+              <label class="label" for="input-net-value">R$ Líquido:</label>
+              <input
+                nbInput
+                [(ngModel)]="teamMember.netValue"
+                (ngModelChange)="updatePercentage()"
+                #netValue="ngModel"
+                id="input-netValue"
+                name="netValue"
+                placeholder="Valor líquido"
+                fullWidth
+                fieldSize="large"
+                [brmasker]="{
+                  money: true,
+                  thousand: '.',
+                  decimalCaracter: ',',
+                  decimal: 2
+                }"
+                ngxSelectAllText
+                [status]="netValue.value ? 'success' : 'basic'"
+                [attr.aria-invalid]="
+                  netValue.invalid && netValue.touched ? true : null
+                "
+              />
+            </div>
           </div>
           <div class="col-6 col-md-2">
             <div class="form-control-group">
@@ -694,6 +694,16 @@
                 >
                   R$ {{ teamTotal.netValue }}
                 </div>
+                <div
+                  class="col-2"
+                  [ngClass]="{
+                    danger: teamTotal.distribution != '0,00',
+                    success: teamTotal.distribution == '100,00'
+                  }"
+                >
+                  {{ teamTotal.distribution }}%
+                </div>
+                <div class="col-1"></div>
               </div>
             </nb-list-item>
           </nb-list>
@@ -732,94 +742,94 @@
               </nb-select>
             </div>
           </div>
-        </div>
-        <div class="col-6">
-          <div class="form-control-group">
-            <label class="label" for="input-iss">Alíquota do ISS:</label>
-            <input
-              nbInput
-              [(ngModel)]="contract.ISS"
-              #iss="ngModel"
-              id="input-iss"
-              name="iss"
-              placeholder="Alíquota"
-              fullWidth
-              fieldSize="large"
-              [brmasker]="{
-                money: true,
-                thousand: '.',
-                decimalCaracter: ',',
-                decimal: 2
-              }"
-              ngxSelectAllText
-              [disabled]="!hasISS.value"
-              [required]="validation.ISS?.required"
-              [status]="
-                iss.dirty ? (iss.invalid ? 'danger' : 'success') : 'basic'
-              "
-              [attr.aria-invalid]="iss.invalid && iss.touched ? true : null"
-              (ngModelChange)="updateLiquid()"
-            />
+          <div class="col-6">
+            <div class="form-control-group">
+              <label class="label" for="input-iss">Alíquota do ISS:</label>
+              <input
+                nbInput
+                [(ngModel)]="contract.ISS"
+                #iss="ngModel"
+                id="input-iss"
+                name="iss"
+                placeholder="Alíquota"
+                fullWidth
+                fieldSize="large"
+                [brmasker]="{
+                  money: true,
+                  thousand: '.',
+                  decimalCaracter: ',',
+                  decimal: 2
+                }"
+                ngxSelectAllText
+                [disabled]="!hasISS.value"
+                [required]="validation.ISS?.required"
+                [status]="
+                  iss.dirty ? (iss.invalid ? 'danger' : 'success') : 'basic'
+                "
+                [attr.aria-invalid]="iss.invalid && iss.touched ? true : null"
+                (ngModelChange)="updateLiquid()"
+              />
+            </div>
           </div>
-        </div>
-        <div class="col-6 col-md-4">
-          <div class="form-control-group">
-            <label class="label" for="input-balance">Caixa:</label>
-            <input
-              nbInput
-              [(ngModel)]="contract.balance"
-              #balance="ngModel"
-              id="input-balance"
-              name="balance"
-              placeholder="Balanço do contrato"
-              fullWidth
-              fieldSize="large"
-              [brmasker]="{
-                money: true,
-                thousand: '.',
-                decimalCaracter: ',',
-                decimal: 2
-              }"
-              ngxSelectAllText
-              [required]="validation.balance?.required"
-              [status]="
-                balance.invalid || contract.balance[0] == '-'
-                  ? 'danger'
-                  : 'basic'
-              "
-              [attr.aria-invalid]="
-                balance.invalid && balance.touched ? true : null
-              "
-              [readonly]="true"
-            />
+          <div class="col-6 col-md-4">
+            <div class="form-control-group">
+              <label class="label" for="input-balance">Caixa:</label>
+              <input
+                nbInput
+                [(ngModel)]="contract.balance"
+                #balance="ngModel"
+                id="input-balance"
+                name="balance"
+                placeholder="Balanço do contrato"
+                fullWidth
+                fieldSize="large"
+                [brmasker]="{
+                  money: true,
+                  thousand: '.',
+                  decimalCaracter: ',',
+                  decimal: 2
+                }"
+                ngxSelectAllText
+                [required]="validation.balance?.required"
+                [status]="
+                  balance.invalid || contract.balance[0] == '-'
+                    ? 'danger'
+                    : 'basic'
+                "
+                [attr.aria-invalid]="
+                  balance.invalid && balance.touched ? true : null
+                "
+                [readonly]="true"
+              />
+            </div>
           </div>
-        </div>
-        <div class="col-6 col-md-4">
-          <div class="form-control-group">
-            <label class="label" for="input-paid">Valor pago:</label>
-            <input
-              nbInput
-              [(ngModel)]="options.paid"
-              #paid="ngModel"
-              id="input-paid"
-              name="paid"
-              placeholder="Valor pago"
-              fullWidth
-              fieldSize="large"
-              [brmasker]="{
-                money: true,
-                thousand: '.',
-                decimalCaracter: ',',
-                decimal: 2
-              }"
-              ngxSelectAllText
-              [required]="validation.paid?.required"
-              [status]="
-                paid.dirty ? (paid.invalid ? 'danger' : 'success') : 'basic'
-              "
-              [attr.aria-invalid]="paid.invalid && paid.touched ? true : null"
-              [readonly]="true"
-            />
+          <div class="col-6 col-md-4">
+            <div class="form-control-group">
+              <label class="label" for="input-paid">Valor pago:</label>
+              <input
+                nbInput
+                [(ngModel)]="options.paid"
+                #paid="ngModel"
+                id="input-paid"
+                name="paid"
+                placeholder="Valor pago"
+                fullWidth
+                fieldSize="large"
+                [brmasker]="{
+                  money: true,
+                  thousand: '.',
+                  decimalCaracter: ',',
+                  decimal: 2
+                }"
+                ngxSelectAllText
+                [required]="validation.paid?.required"
+                [status]="
+                  paid.dirty ? (paid.invalid ? 'danger' : 'success') : 'basic'
+                "
+                [attr.aria-invalid]="paid.invalid && paid.touched ? true : null"
+                [readonly]="true"
+              />
+            </div>
           </div>
           <div class="col-6 col-md-2">
             <div class="form-control-group">

--- a/src/app/pages/contracts/contract-item/contract-item.component.html
+++ b/src/app/pages/contracts/contract-item/contract-item.component.html
@@ -619,7 +619,7 @@
                       decimal: 2
                     }"
                     ngxSelectAllText
-                    [status]="contract.team[i].netValue ? 'basic' : 'danger'"
+                    [status]="invoice.team[i].netValue ? 'basic' : 'danger'"
                   />
                 </div>
                 <div
@@ -628,7 +628,7 @@
                 >
                   <input
                     nbInput
-                    [(ngModel)]="contract.team[i].distribution"
+                    [(ngModel)]="invoice.team[i].distribution"
                     (ngModelChange)="updateValue(i)"
                     id="input-distribution-{{ i }}"
                     name="distribution-{{ i }}"
@@ -642,7 +642,7 @@
                     }"
                     ngxSelectAllText
                     [status]="
-                      contract.team[i].distribution ? 'basic' : 'danger'
+                      invoice.team[i].distribution ? 'basic' : 'danger'
                     "
                   />
                   %
@@ -654,7 +654,7 @@
                     icon="trash-2-outline"
                     pack="eva"
                     (click)="
-                      contract.team.splice(i, 1);
+                      invoice.team.splice(i, 1);
                       updateTeamTotal();
                       memberChanged$.next(true)
                     "

--- a/src/app/pages/contracts/contract-item/contract-item.component.html
+++ b/src/app/pages/contracts/contract-item/contract-item.component.html
@@ -525,17 +525,17 @@
                 name="distribution"
                 placeholder="Porcentagem distribuida"
                 fullWidth
-              fieldSize="large"
-              [brmasker]="{
-                money: true,
-                thousand: '.',
-                decimalCaracter: ',',
-                decimal: 20
-              }"
-              ngxSelectAllText
-              [status]="distribution.value ? 'success' : 'basic'"
-              [attr.aria-invalid]="
-                distribution.invalid && distribution.touched ? true : null
+                fieldSize="large"
+                [brmasker]="{
+                  money: true,
+                  thousand: '.',
+                  decimalCaracter: ',',
+                  decimal: 20
+                }"
+                ngxSelectAllText
+                [status]="distribution.value ? 'success' : 'basic'"
+                [attr.aria-invalid]="
+                  distribution.invalid && distribution.touched ? true : null
                 "
               />
             </div>
@@ -545,7 +545,6 @@
               nbButton
               type="button"
               fullWidth
-
               status="primary"
               size="large"
               style="margin-top: 28px"
@@ -619,79 +618,84 @@
                       decimalCaracter: ',',
                       decimal: 2
                     }"
-                  ngxSelectAllText
-                  [status]="contract.team[i].netValue ? 'basic' : 'danger'"
-                />
+                    ngxSelectAllText
+                    [status]="contract.team[i].netValue ? 'basic' : 'danger'"
+                  />
+                </div>
+                <div
+                  class="col-6 col-md-2"
+                  style="display: flex; align-items: center"
+                >
+                  <input
+                    nbInput
+                    [(ngModel)]="contract.team[i].distribution"
+                    (ngModelChange)="updateValue(i)"
+                    id="input-distribution-{{ i }}"
+                    name="distribution-{{ i }}"
+                    placeholder="Porcentagem distribuida"
+                    fullWidth
+                    [brmasker]="{
+                      money: true,
+                      thousand: '.',
+                      decimalCaracter: ',',
+                      decimal: 20
+                    }"
+                    ngxSelectAllText
+                    [status]="
+                      contract.team[i].distribution ? 'basic' : 'danger'
+                    "
+                  />
+                  %
+                </div>
+                <div class="col-12 col-md-1 list-erase">
+                  <nb-icon
+                    class="xIcon"
+                    status="basic"
+                    icon="trash-2-outline"
+                    pack="eva"
+                    (click)="
+                      contract.team.splice(i, 1);
+                      updateTeamTotal();
+                      memberChanged$.next(true)
+                    "
+                    [options]="{ animation: { type: 'shake' } }"
+                  ></nb-icon>
+                </div>
               </div>
-              <div
-                class="col-6 col-md-2"
-                style="display: flex; align-items: center"
-              >
-                <input
-                  nbInput
-                  [(ngModel)]="contract.team[i].distribution"
-                  (ngModelChange)="updateValue(i)"
-                  id="input-distribution-{{ i }}"
-                  name="distribution-{{ i }}"
-                  placeholder="Porcentagem distribuida"
-                  fullWidth
-                  [brmasker]="{
-                    money: true,
-                    thousand: '.',
-                    decimalCaracter: ',',
-                    decimal: 20
+            </nb-list-item>
+            <nb-list-item *ngIf="!utils.isPhone()">
+              <div class="row irow totalRow">
+                <div class="col-2">
+                  Restante:
+                  {{
+                    stringUtil.subtractMoney(
+                      contract.liquid,
+                      teamTotal.netValue
+                    )
+                  }}
+                </div>
+                <div class="col-3" style="text-align: right">Total:</div>
+                <div
+                  class="col-2"
+                  [ngClass]="{
+                    danger: !isGrossValueOK(),
+                    success: isGrossValueOK()
                   }"
-                  ngxSelectAllText
-                  [status]="contract.team[i].distribution ? 'basic' : 'danger'"
-                />
-                %
+                >
+                  R$ {{ teamTotal.grossValue }}
+                </div>
+                <div
+                  class="col-2"
+                  [ngClass]="{
+                    danger: !isNetValueOK(),
+                    success: isNetValueOK()
+                  }"
+                >
+                  R$ {{ teamTotal.netValue }}
+                </div>
               </div>
-              <div class="col-12 col-md-1 list-erase">
-                <nb-icon
-                  class="xIcon"
-                  status="basic"
-                  icon="trash-2-outline"
-                  pack="eva"
-                  (click)="
-                    contract.team.splice(i, 1);
-                    updateTeamTotal();
-                    memberChanged$.next(true)
-                  "
-                  [options]="{ animation: { type: 'shake' } }"
-                ></nb-icon>
-              </div>
-            </div>
-          </nb-list-item>
-          <nb-list-item *ngIf="!utils.isPhone()">
-            <div class="row irow totalRow">
-              <div class="col-2">
-                Restante:
-                {{
-                  stringUtil.subtractMoney(contract.liquid, teamTotal.netValue)
-                }}
-              </div>
-              <div class="col-3" style="text-align: right">Total:</div>
-              <div
-                class="col-2"
-                [ngClass]="{
-                  danger: !isGrossValueOK(),
-                  success: isGrossValueOK()
-                }"
-              >
-                R$ {{ teamTotal.grossValue }}
-              </div>
-              <div
-                class="col-2"
-                [ngClass]="{
-                  danger: !isNetValueOK(),
-                  success: isNetValueOK()
-                }"
-              >
-                R$ {{ teamTotal.netValue }}
-              </div>
-            </div>
-          </nb-list-item>
-        </nb-list>
+            </nb-list-item>
+          </nb-list>
           <div class="col-6">
             <div class="form-control-group">
               <label class="label" for="input-hasISS">
@@ -726,6 +730,7 @@
                 <nb-option [value]="false">Não</nb-option>
               </nb-select>
             </div>
+          </div>
         </div>
         <div class="col-6">
           <div class="form-control-group">

--- a/src/app/pages/contracts/contract-item/contract-item.component.html
+++ b/src/app/pages/contracts/contract-item/contract-item.component.html
@@ -641,13 +641,14 @@
                       decimal: 20
                     }"
                     ngxSelectAllText
-                    [status]="
-                      invoice.team[i].distribution ? 'basic' : 'danger'
-                    "
+                    [status]="invoice.team[i].distribution ? 'basic' : 'danger'"
                   />
                   %
                 </div>
-                <div class="col-12 col-md-1 list-erase">
+                <div
+                  class="col-12 col-md-1 list-erase"
+                  *ngIf="i != 0 && isEditionGranted"
+                >
                   <nb-icon
                     class="xIcon"
                     status="basic"

--- a/src/app/pages/contracts/contract-item/expense-item/expense-item.component.html
+++ b/src/app/pages/contracts/contract-item/expense-item/expense-item.component.html
@@ -50,8 +50,8 @@
             name="userList"
             placeholder="Digite e selecione o nome do colaborador"
             textNoResults="
-          Não foi possível achar um colaborador com o nome digitado
-          "
+              Não foi possível achar um colaborador com o nome digitado
+              "
             fieldSize="large"
             nameField="fullName"
             pictureField="profilePicture"
@@ -103,6 +103,7 @@
               decimalCaracter: ',',
               decimal: 2
             }"
+            ngxSelectAllText
             [required]="validation.value.required"
             [minLength]="validation.value.minLength"
             [maxLength]="validation.value.maxLength"
@@ -422,46 +423,48 @@
                 </nb-option>
               </nb-select>
             </div>
-            <div class="col-6 col-md-3">
-              <input
-                nbInput
-                [(ngModel)]="expense.team[i].value"
-                (ngModelChange)="updatePercentage(i)"
-                id="input-team-value-{{ i }}"
-                name="team-value-{{ i }}"
-                placeholder="Valor do gasto"
-                fullWidth
-                [brmasker]="{
-                  money: true,
-                  thousand: '.',
-                  decimalCaracter: ',',
-                  decimal: 2
-                }"
-                [status]="is100 ? 'success' : 'basic'"
-              />
-            </div>
-            <div
-              class="col-6 col-md-3"
-              style="display: flex; align-items: center"
-            >
-              <input
-                nbInput
-                [(ngModel)]="expense.team[i].percentage"
-                (ngModelChange)="updateValue(i)"
-                id="input-team-percentage-{{ i }}"
-                name="team-percentage-{{ i }}"
-                placeholder="Porcentagem do gasto"
-                fullWidth
-                [brmasker]="{
-                  money: true,
-                  thousand: '.',
-                  decimalCaracter: ',',
-                  decimal: 2
-                }"
-                [status]="is100 ? 'success' : 'basic'"
-              />
-              %
-            </div>
+          </div>
+          <div class="col-6 col-md-3">
+            <input
+              nbInput
+              [(ngModel)]="expense.team[i].value"
+              (ngModelChange)="updatePercentage(i)"
+              id="input-team-value-{{ i }}"
+              name="team-value-{{ i }}"
+              placeholder="Valor do gasto"
+              fullWidth
+              [brmasker]="{
+                money: true,
+                thousand: '.',
+                decimalCaracter: ',',
+                decimal: 2
+              }"
+              ngxSelectAllText
+              [status]="is100 ? 'success' : 'basic'"
+            />
+          </div>
+          <div
+            class="col-6 col-md-3"
+            style="display: flex; align-items: center"
+          >
+            <input
+              nbInput
+              [(ngModel)]="expense.team[i].percentage"
+              (ngModelChange)="updateValue(i)"
+              id="input-team-percentage-{{ i }}"
+              name="team-percentage-{{ i }}"
+              placeholder="Porcentagem do gasto"
+              fullWidth
+              [brmasker]="{
+                money: true,
+                thousand: '.',
+                decimalCaracter: ',',
+                decimal: 2
+              }"
+              ngxSelectAllText
+              [status]="is100 ? 'success' : 'basic'"
+            />
+            %
           </div>
         </nb-list-item>
       </nb-list>

--- a/src/app/pages/contracts/contract-item/expense-item/expense-item.component.html
+++ b/src/app/pages/contracts/contract-item/expense-item/expense-item.component.html
@@ -423,48 +423,48 @@
                 </nb-option>
               </nb-select>
             </div>
-          </div>
-          <div class="col-6 col-md-3">
-            <input
-              nbInput
-              [(ngModel)]="expense.team[i].value"
-              (ngModelChange)="updatePercentage(i)"
-              id="input-team-value-{{ i }}"
-              name="team-value-{{ i }}"
-              placeholder="Valor do gasto"
-              fullWidth
-              [brmasker]="{
-                money: true,
-                thousand: '.',
-                decimalCaracter: ',',
-                decimal: 2
-              }"
-              ngxSelectAllText
-              [status]="is100 ? 'success' : 'basic'"
-            />
-          </div>
-          <div
-            class="col-6 col-md-3"
-            style="display: flex; align-items: center"
-          >
-            <input
-              nbInput
-              [(ngModel)]="expense.team[i].percentage"
-              (ngModelChange)="updateValue(i)"
-              id="input-team-percentage-{{ i }}"
-              name="team-percentage-{{ i }}"
-              placeholder="Porcentagem do gasto"
-              fullWidth
-              [brmasker]="{
-                money: true,
-                thousand: '.',
-                decimalCaracter: ',',
-                decimal: 2
-              }"
-              ngxSelectAllText
-              [status]="is100 ? 'success' : 'basic'"
-            />
-            %
+            <div class="col-6 col-md-3">
+              <input
+                nbInput
+                [(ngModel)]="expense.team[i].value"
+                (ngModelChange)="updatePercentage(i)"
+                id="input-team-value-{{ i }}"
+                name="team-value-{{ i }}"
+                placeholder="Valor do gasto"
+                fullWidth
+                [brmasker]="{
+                  money: true,
+                  thousand: '.',
+                  decimalCaracter: ',',
+                  decimal: 2
+                }"
+                ngxSelectAllText
+                [status]="is100 ? 'success' : 'basic'"
+              />
+            </div>
+            <div
+              class="col-6 col-md-3"
+              style="display: flex; align-items: center"
+            >
+              <input
+                nbInput
+                [(ngModel)]="expense.team[i].percentage"
+                (ngModelChange)="updateValue(i)"
+                id="input-team-percentage-{{ i }}"
+                name="team-percentage-{{ i }}"
+                placeholder="Porcentagem do gasto"
+                fullWidth
+                [brmasker]="{
+                  money: true,
+                  thousand: '.',
+                  decimalCaracter: ',',
+                  decimal: 2
+                }"
+                ngxSelectAllText
+                [status]="is100 ? 'success' : 'basic'"
+              />
+              %
+            </div>
           </div>
         </nb-list-item>
       </nb-list>

--- a/src/app/pages/contracts/contract-item/payment-item/payment-item.component.html
+++ b/src/app/pages/contracts/contract-item/payment-item/payment-item.component.html
@@ -67,6 +67,7 @@
               decimalCaracter: ',',
               decimal: 2
             }"
+            ngxSelectAllText
             [disabled]="paymentIndex != undefined"
             [overPaid]="contract.balance"
             [required]="validation.value.required"
@@ -420,6 +421,7 @@
               decimalCaracter: ',',
               decimal: 2
             }"
+            ngxSelectAllText
             [status]="paid.value ? 'success' : 'basic'"
             [attr.aria-invalid]="paid.invalid && paid.touched ? true : null"
             [readonly]="false"
@@ -489,6 +491,7 @@
                 decimalCaracter: ',',
                 decimal: 2
               }"
+              ngxSelectAllText
               [status]="
                 paymentIndex === undefined
                   ? is100
@@ -518,6 +521,7 @@
                 decimalCaracter: ',',
                 decimal: 2
               }"
+              ngxSelectAllText
               [status]="
                 paymentIndex === undefined
                   ? is100

--- a/src/app/pages/contracts/contract-item/receipt-item/receipt-item.component.html
+++ b/src/app/pages/contracts/contract-item/receipt-item/receipt-item.component.html
@@ -67,6 +67,7 @@
               decimalCaracter: ',',
               decimal: 2
             }"
+            ngxSelectAllText
             [overPaid]="notPaid()"
             [lastPayment]="lastPayment()"
             [required]="validation.value.required"
@@ -128,6 +129,7 @@
               decimalCaracter: ',',
               decimal: 2
             }"
+            ngxSelectAllText
             [required]="validation.nf.required"
             [status]="
               nf.dirty
@@ -162,6 +164,7 @@
               decimalCaracter: ',',
               decimal: 2
             }"
+            ngxSelectAllText
             [required]="validation.nortan.required"
             [status]="
               nortan.dirty
@@ -196,6 +199,7 @@
               decimalCaracter: ',',
               decimal: 2
             }"
+            ngxSelectAllText
             [required]="validation.liquid.required"
             [status]="
               receiptIndex === undefined

--- a/src/app/pages/dashboard/nortan-expenses/nortan-expense-item/nortan-expense-item.component.html
+++ b/src/app/pages/dashboard/nortan-expenses/nortan-expense-item/nortan-expense-item.component.html
@@ -64,6 +64,7 @@
             decimalCaracter: ',',
             decimal: 2
           }"
+          ngxSelectAllText
           [required]="validation.value.required"
           [minLength]="validation.value.minLength"
           [maxLength]="validation.value.maxLength"

--- a/src/app/pages/invoices/invoice-item/invoice-item.component.html
+++ b/src/app/pages/invoices/invoice-item/invoice-item.component.html
@@ -368,6 +368,7 @@
                 decimalCaracter: ',',
                 decimal: 2
               }"
+              ngxSelectAllText
               [required]="validation.value.required"
               [minlength]="validation.value.minLength"
               [maxlength]="validation.value.maxLength"
@@ -421,6 +422,7 @@
                 decimalCaracter: ',',
                 decimal: 2
               }"
+              ngxSelectAllText
               [required]="validation.value.required"
               [minlength]="validation.value.minLength"
               [maxlength]="validation.value.maxLength"
@@ -1418,6 +1420,7 @@
                 decimalCaracter: ',',
                 decimal: 2
               }"
+              ngxSelectAllText
               [status]="productAmount.value ? 'success' : 'basic'"
               [attr.aria-invalid]="
                 productAmount.invalid && productAmount.touched ? true : null
@@ -1489,6 +1492,7 @@
                 decimalCaracter: ',',
                 decimal: 2
               }"
+              ngxSelectAllText
               [status]="paid.value ? 'success' : 'basic'"
               [attr.aria-invalid]="paid.invalid && paid.touched ? true : null"
             />
@@ -1513,6 +1517,7 @@
                 decimalCaracter: ',',
                 decimal: 2
               }"
+              ngxSelectAllText
               [status]="productTotal.value ? 'success' : 'basic'"
               [attr.aria-invalid]="
                 productTotal.invalid && productTotal.touched ? true : null
@@ -1632,6 +1637,7 @@
                   decimalCaracter: ',',
                   decimal: 2
                 }"
+                ngxSelectAllText
                 [status]="tempInvoice.products[i].amount ? 'success' : 'basic'"
               />
             </div>
@@ -1679,6 +1685,7 @@
                   decimalCaracter: ',',
                   decimal: 2
                 }"
+                ngxSelectAllText
                 [status]="tempInvoice.products[i].value ? 'success' : 'basic'"
               />
             </div>
@@ -1703,6 +1710,7 @@
                   decimalCaracter: ',',
                   decimal: 2
                 }"
+                ngxSelectAllText
                 [status]="tempInvoice.products[i].value ? 'success' : 'basic'"
               />
               %
@@ -1774,6 +1782,7 @@
                   decimalCaracter: ',',
                   decimal: 2
                 }"
+                ngxSelectAllText
                 [status]="
                   discountValue.dirty
                     ? discountValue.value
@@ -1805,6 +1814,7 @@
                   decimalCaracter: ',',
                   decimal: 2
                 }"
+                ngxSelectAllText
                 [status]="
                   discountPercentage.dirty
                     ? discountPercentage.value
@@ -1908,6 +1918,7 @@
                 decimalCaracter: ',',
                 decimal: 2
               }"
+              ngxSelectAllText
               [status]="stagePaid.value ? 'success' : 'basic'"
               [attr.aria-invalid]="
                 stagePaid.invalid && stagePaid.touched ? true : null
@@ -1969,6 +1980,7 @@
                   decimalCaracter: ',',
                   decimal: 2
                 }"
+                ngxSelectAllText
                 [status]="tempInvoice.stages[i].value ? 'success' : 'basic'"
               />
             </div>
@@ -1992,6 +2004,7 @@
                   decimalCaracter: ',',
                   decimal: 2
                 }"
+                ngxSelectAllText
                 [status]="tempInvoice.stages[i].value ? 'success' : 'basic'"
               />
               %
@@ -2220,6 +2233,7 @@
                   decimalCaracter: ',',
                   decimal: 2
                 }"
+                ngxSelectAllText
                 [status]="materialAmount.value ? 'success' : 'basic'"
                 [attr.aria-invalid]="
                   materialAmount.invalid && materialAmount.touched ? true : null
@@ -2249,6 +2263,7 @@
                 decimalCaracter: ',',
                 decimal: 2
               }"
+              ngxSelectAllText
               [status]="materialValue.value ? 'success' : 'basic'"
               [attr.aria-invalid]="
                 materialValue.invalid && materialValue.touched ? true : null
@@ -2278,6 +2293,7 @@
                 decimalCaracter: ',',
                 decimal: 2
               }"
+              ngxSelectAllText
               [status]="materialTotal.value ? 'success' : 'basic'"
               [attr.aria-invalid]="
                 materialTotal.invalid && materialTotal.touched ? true : null
@@ -2371,6 +2387,7 @@
                     decimalCaracter: ',',
                     decimal: 2
                   }"
+                  ngxSelectAllText
                   [status]="
                     tempInvoice.materials[i].amount.length == 0
                       ? 'danger'
@@ -2400,6 +2417,7 @@
                   decimalCaracter: ',',
                   decimal: 2
                 }"
+                ngxSelectAllText
                 [status]="
                   tempInvoice.materials[i].value.length == 0
                     ? 'danger'

--- a/src/app/pages/profile/profile.component.html
+++ b/src/app/pages/profile/profile.component.html
@@ -284,6 +284,7 @@
                       fullWidth
                       fieldSize="large"
                       [brmasker]="{ person: true }"
+                      ngxSelectAllText
                       [required]="validation.document.required"
                       [minlength]="validation.document.minLength"
                       [maxlength]="validation.document.maxLength"
@@ -333,6 +334,7 @@
                       fullWidth
                       fieldSize="large"
                       [brmasker]="{ phone: true }"
+                      ngxSelectAllText
                       [required]="validation.phone.required"
                       [minlength]="validation.phone.minLength"
                       [maxlength]="validation.phone.maxLength"

--- a/src/app/pages/promotions/promotion-item/promotion-item.component.html
+++ b/src/app/pages/promotions/promotion-item/promotion-item.component.html
@@ -36,9 +36,9 @@
     </div>
     <div class="col-4">
       <div class="form-control-group">
-        <label class="label" for="input-cashback"
-          >Porcentagem de cashback:</label
-        >
+        <label class="label" for="input-cashback">
+          Porcentagem de cashback:
+        </label>
         <input
           nbInput
           [(ngModel)]="promotion.cashback"
@@ -56,6 +56,7 @@
             decimalCaracter: ',',
             decimal: 2
           }"
+          ngxSelectAllText
           [status]="validateStatus(cashback)"
           [attr.aria-invalid]="
             cashback.invalid && cashback.touched ? true : null
@@ -258,6 +259,7 @@
             decimalCaracter: ',',
             decimal: 2
           }"
+          ngxSelectAllText
           [status]="validateStatus(ruleValue)"
           [attr.aria-invalid]="
             ruleValue.invalid && ruleValue.touched ? true : null
@@ -279,8 +281,7 @@
     *ngIf="!utils.isPhone(); else phone"
     [settings]="settings"
     [source]="source"
-  >
-  </ng2-smart-table>
+  ></ng2-smart-table>
   <ng-template #phone></ng-template>
 </form>
 <button

--- a/src/app/pages/promotions/promotions.component.html
+++ b/src/app/pages/promotions/promotions.component.html
@@ -42,8 +42,7 @@
           [source]="source"
           (edit)="promotionDialog($event)"
           (create)="promotionDialog({})"
-        >
-        </ng2-smart-table>
+        ></ng2-smart-table>
       </ng-template>
       <ng-template #phone>
         <nb-list>
@@ -57,8 +56,7 @@
                     size="giant"
                     [name]="promotion.name"
                     [title]="promotion.name"
-                  >
-                  </nb-user>
+                  ></nb-user>
                 </div>
                 <div class="col-12">
                   <p>

--- a/src/app/pages/users/users.component.html
+++ b/src/app/pages/users/users.component.html
@@ -41,8 +41,7 @@
           [settings]="settings"
           [source]="source"
           (edit)="userDialog($event)"
-        >
-        </ng2-smart-table>
+        ></ng2-smart-table>
       </ng-template>
       <ng-template #phone>
         <nb-list>
@@ -54,8 +53,7 @@
                     size="giant"
                     [name]="user.fullName"
                     [title]="user.document"
-                  >
-                  </nb-user>
+                  ></nb-user>
                 </div>
                 <div class="col-12">
                   <p>

--- a/src/app/shared/directives/select-all-text.directive.ts
+++ b/src/app/shared/directives/select-all-text.directive.ts
@@ -1,0 +1,14 @@
+import { Directive, ElementRef, HostListener } from '@angular/core';
+
+@Directive({
+  selector: '[ngxSelectAllText]',
+})
+export class SelectAllTextDirective {
+  constructor(
+    private element: ElementRef<HTMLInputElement | HTMLTextAreaElement>
+  ) {}
+
+  @HostListener('focusin') onFocusIn(): void {
+    this.element.nativeElement.select();
+  }
+}

--- a/src/app/shared/services/contract.service.ts
+++ b/src/app/shared/services/contract.service.ts
@@ -12,6 +12,7 @@ import { User } from '@models/user';
 import { Contract, ContractExpense } from '@models/contract';
 import { Invoice } from '@models/invoice';
 import { parseISO } from 'date-fns';
+import { cloneDeep } from 'lodash';
 
 export enum EXPENSE_TYPES {
   APORTE = 'Aporte',
@@ -68,7 +69,7 @@ export class ContractService implements OnDestroy {
   }
 
   saveContract(invoice: Invoice): void {
-    let contract = new Contract();
+    const contract = new Contract();
     contract.statusHistory.push({
       status: contract.status,
       start: contract.created,

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -19,6 +19,7 @@ import { BaseDialogComponent } from './components/base-dialog/base-dialog.compon
 import { FabComponent } from './components/fab/fab.component';
 import { FabItemComponent } from './components/fab/fab-item/fab-item.component';
 import { BaseExpenseComponent } from './components/base-expense/base-expense.component';
+import { SelectAllTextDirective } from './directives/select-all-text.directive';
 
 @NgModule({
   imports: [
@@ -37,6 +38,7 @@ import { BaseExpenseComponent } from './components/base-expense/base-expense.com
     LastPaymentDirective,
     FabComponent,
     FabItemComponent,
+    SelectAllTextDirective,
   ],
   declarations: [
     BrMaskDirective,
@@ -49,6 +51,7 @@ import { BaseExpenseComponent } from './components/base-expense/base-expense.com
     FabComponent,
     FabItemComponent,
     BaseExpenseComponent,
+    SelectAllTextDirective,
   ],
 })
 export class SharedModule {}


### PR DESCRIPTION
Adiciona uma diretiva customizada que recebe a referência de um elemento do tipo Input ou TextArea e executa nele a função select() que seleciona todo o texto no elemento.

Caso haja problemas de compatibilidade do browser, é possível substituir a função pela setSelectionRange().

Edit: a diretiva customizada foi incluída em cada ocorrência do brMask.